### PR TITLE
Correct saving inside publish for ruby 3.0.0

### DIFF
--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -184,7 +184,7 @@ class Draftsman::Draft < ActiveRecord::Base
         # Clear out draft
         self.item.send("#{self.item.class.draft_association_name}_id=", nil)
 
-        self.item.save(self.item.draftsman_options[:publish_options].merge(options))
+        self.item.save(**self.item.draftsman_options[:publish_options].merge(options))
         self.item.reload
 
         # Destroy draft


### PR DESCRIPTION
Pass keywords instead of a Hash for save inside publish! method for ruby 3.0.0